### PR TITLE
Added alternative to catkin build

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ Figure by: Kristoffer Rakstad Solberg
 	cd ~/vortex_ws/
 	catkin build
 	```
+	
+	If catkin build crashes your pc, try:
+	```bash
+	catkin build -j2
+	```
+	This should limit the amount of cpu recources used whilst building.
+	
 ## 2. Run Vortex Simulator ##
 -------------------------
 


### PR DESCRIPTION
Tarek found this trick and it worked for both him and me, so I thought this should be in the main wiki, as it's a problem affecting several people.
Running katkin build without -j2 would cause the PC to freeze for eternity. -j2 should limit the amount of cores used and allow the system to remain functional whilst building.